### PR TITLE
Make first person arm translucent when you have invisibility

### DIFF
--- a/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinPlayerRenderer.java
+++ b/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinPlayerRenderer.java
@@ -25,11 +25,13 @@ package btw.mixces.animatium.mixins.renderer.entity;
 
 import btw.mixces.animatium.AnimatiumClient;
 import btw.mixces.animatium.config.AnimatiumConfig;
+import btw.mixces.animatium.util.PlayerUtils;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.PlayerModel;
@@ -41,6 +43,7 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.client.renderer.entity.state.PlayerRenderState;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.ARGB;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.HumanoidArm;
 import org.jetbrains.annotations.NotNull;
@@ -115,5 +118,12 @@ public abstract class MixinPlayerRenderer extends LivingEntityRenderer<AbstractC
                 modelPart.yRot = 0.0F;
             }
         }
+    }
+
+    @WrapOperation(method = "renderHand", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/geom/ModelPart;render(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;II)V"))
+    private void renderTrans(ModelPart instance, PoseStack poseStack, VertexConsumer buffer, int packedLight, int packedOverlay, Operation<Void> original) {
+        AbstractClientPlayer player = Minecraft.getInstance().player;
+        if (player != null && player.isInvisible()) instance.render(poseStack, buffer, packedLight, packedOverlay, ARGB.colorFromFloat(0.5F, 1F, 1F, 1F)); // TODO: change alpha value to proper value & require config option
+        else original.call(instance, poseStack, buffer, packedLight, packedOverlay);
     }
 }

--- a/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinPlayerRenderer.java
+++ b/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinPlayerRenderer.java
@@ -25,7 +25,6 @@ package btw.mixces.animatium.mixins.renderer.entity;
 
 import btw.mixces.animatium.AnimatiumClient;
 import btw.mixces.animatium.config.AnimatiumConfig;
-import btw.mixces.animatium.util.PlayerUtils;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;

--- a/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinPlayerRenderer.java
+++ b/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinPlayerRenderer.java
@@ -122,8 +122,8 @@ public abstract class MixinPlayerRenderer extends LivingEntityRenderer<AbstractC
     @WrapOperation(method = "renderHand", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/geom/ModelPart;render(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;II)V"))
     private void animatium$renderTranslucentFirstPersonArm(ModelPart instance, PoseStack poseStack, VertexConsumer buffer, int packedLight, int packedOverlay, Operation<Void> original) {
         AbstractClientPlayer player = Minecraft.getInstance().player;
-        if (player != null && player.isInvisible()) {
-            instance.render(poseStack, buffer, packedLight, packedOverlay, ARGB.colorFromFloat(0.5F, 1F, 1F, 1F)); // TODO: change alpha value to proper value
+        if (AnimatiumClient.getEnabled() && AnimatiumConfig.instance().getShowArmWhileInvisible() && player != null && player.isInvisible()) {
+            instance.render(poseStack, buffer, packedLight, packedOverlay, ARGB.colorFromFloat(38F / 255F, 1F, 1F, 1F)); // TODO: change alpha value to proper value
         } else {
             original.call(instance, poseStack, buffer, packedLight, packedOverlay);
         }

--- a/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinPlayerRenderer.java
+++ b/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinPlayerRenderer.java
@@ -120,9 +120,12 @@ public abstract class MixinPlayerRenderer extends LivingEntityRenderer<AbstractC
     }
 
     @WrapOperation(method = "renderHand", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/model/geom/ModelPart;render(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;II)V"))
-    private void renderTrans(ModelPart instance, PoseStack poseStack, VertexConsumer buffer, int packedLight, int packedOverlay, Operation<Void> original) {
+    private void animatium$renderTranslucentFirstPersonArm(ModelPart instance, PoseStack poseStack, VertexConsumer buffer, int packedLight, int packedOverlay, Operation<Void> original) {
         AbstractClientPlayer player = Minecraft.getInstance().player;
-        if (player != null && player.isInvisible()) instance.render(poseStack, buffer, packedLight, packedOverlay, ARGB.colorFromFloat(0.5F, 1F, 1F, 1F)); // TODO: change alpha value to proper value & require config option
-        else original.call(instance, poseStack, buffer, packedLight, packedOverlay);
+        if (player != null && player.isInvisible()) {
+            instance.render(poseStack, buffer, packedLight, packedOverlay, ARGB.colorFromFloat(0.5F, 1F, 1F, 1F)); // TODO: change alpha value to proper value
+        } else {
+            original.call(instance, poseStack, buffer, packedLight, packedOverlay);
+        }
     }
 }

--- a/src/main/java/btw/mixces/animatium/mixins/renderer/item/MixinItemInHandRenderer.java
+++ b/src/main/java/btw/mixces/animatium/mixins/renderer/item/MixinItemInHandRenderer.java
@@ -86,7 +86,6 @@ public abstract class MixinItemInHandRenderer {
     @Unique
     private ItemStack animatium$mainHandItem = ItemStack.EMPTY;
 
-    // TODO: Make arm partially translucent/transparent like the third-person player model (like on a team)
     @WrapOperation(method = "renderArmWithItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/AbstractClientPlayer;isInvisible()Z"))
     private boolean animatium$showArmWhileInvisible(AbstractClientPlayer instance, Operation<Boolean> original) {
         if (AnimatiumClient.getEnabled() && AnimatiumConfig.instance().getShowArmWhileInvisible()) {


### PR DESCRIPTION
lowercase asked me to make this (i think).

This makes the first person arm translucent when you are invisible.

I'm not sure what your guys' idea is on config so I didn't touch https://github.com/Legacy-Visuals-Project/Animatium/blob/1.21.4/development/src/main/java/btw/mixces/animatium/mixins/renderer/item/MixinItemInHandRenderer.java#L89 and didn't add a config option for this. Additionally, I don't know what opacity value to use so I defaulted it to 50% for now.

also yes im aware method name needs to be changed as well, will do that later when fixing the rest