### PR TITLE
1.21.5: Add animatium prefix to recipeBookComponent getter

### DIFF
--- a/src/main/java/btw/mixces/animatium/mixins/accessor/AbstractRecipeBookScreenAccessor.java
+++ b/src/main/java/btw/mixces/animatium/mixins/accessor/AbstractRecipeBookScreenAccessor.java
@@ -30,6 +30,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(AbstractRecipeBookScreen.class)
 public interface AbstractRecipeBookScreenAccessor {
-    @Accessor
-    RecipeBookComponent<?> getRecipeBookComponent();
+    @Accessor("recipeBookComponent")
+    RecipeBookComponent<?> aniatmium$getRecipeBookComponent();
 }

--- a/src/main/java/btw/mixces/animatium/mixins/screen/inventory/MixinEffectsInInventory.java
+++ b/src/main/java/btw/mixces/animatium/mixins/screen/inventory/MixinEffectsInInventory.java
@@ -46,7 +46,7 @@ public abstract class MixinEffectsInInventory {
     @WrapOperation(method = "renderEffects", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;imageWidth:I"))
     private int animatium$effectsInventoryPosition(AbstractContainerScreen<?> instance, Operation<Integer> original) {
         final int imageWidth = original.call(instance);
-        if (AnimatiumClient.isEnabled() && AnimatiumConfig.instance().effectsInventoryPosition && !(this.screen instanceof AbstractRecipeBookScreen<?> recipeBookScreen && ((AbstractRecipeBookScreenAccessor) recipeBookScreen).getRecipeBookComponent().isVisible())) {
+        if (AnimatiumClient.isEnabled() && AnimatiumConfig.instance().effectsInventoryPosition && !(this.screen instanceof AbstractRecipeBookScreen<?> recipeBookScreen && ((AbstractRecipeBookScreenAccessor) recipeBookScreen).aniatmium$getRecipeBookComponent().isVisible())) {
             return 0;
         } else {
             return imageWidth;
@@ -55,7 +55,7 @@ public abstract class MixinEffectsInInventory {
 
     @ModifyExpressionValue(method = "renderEffects", at = @At(value = "CONSTANT", args = "intValue=2"))
     private int animatium$effectsInventoryPosition(int original) {
-        if (AnimatiumClient.isEnabled() && AnimatiumConfig.instance().effectsInventoryPosition && !(this.screen instanceof AbstractRecipeBookScreen<?> recipeBookScreen && ((AbstractRecipeBookScreenAccessor) recipeBookScreen).getRecipeBookComponent().isVisible())) {
+        if (AnimatiumClient.isEnabled() && AnimatiumConfig.instance().effectsInventoryPosition && !(this.screen instanceof AbstractRecipeBookScreen<?> recipeBookScreen && ((AbstractRecipeBookScreenAccessor) recipeBookScreen).aniatmium$getRecipeBookComponent().isVisible())) {
             return -124;
         } else {
             return original;


### PR DESCRIPTION
Other mods such as Controllerify use this getter name ([source](https://github.com/isXander/Controlify/blob/37dcf02784a9a96e6cc027d8ff400b176683dbcc/src/main/java/dev/isxander/controlify/mixins/feature/screenop/vanilla/AbstractRecipeBookScreenMixin.java#L21)), which can end up clashing and cause crashes.