### PR TITLE
Fix: Crash due to null player

### DIFF
--- a/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinLivingEntityRenderer.java
+++ b/src/main/java/btw/mixces/animatium/mixins/renderer/entity/MixinLivingEntityRenderer.java
@@ -76,7 +76,7 @@ public abstract class MixinLivingEntityRenderer<S extends LivingEntityRenderStat
         Entity entity = EntityUtils.getEntityByState(livingEntityRenderState);
         if (AnimatiumClient.isEnabled() && !AnimatiumConfig.instance().modelWhilstSleeping &&
                 entity instanceof LivingEntity livingEntity &&
-                livingEntity == Objects.requireNonNull(Minecraft.getInstance().player) &&
+                livingEntity == Minecraft.getInstance().player &&
                 livingEntityRenderState.hasPose(Pose.SLEEPING) &&
                 livingEntity.isSleeping()) {
             ci.cancel();


### PR DESCRIPTION
Using `Objects.requireNonNull()` is generally not recommended in mods. Instead do null checks and run vanilla code as fallback.
Some mods render entities in the main menu, before a player is created. Causing this mod to crash the game.
The `instanceof` prevents `livingEntity` from being `null`, so simply removing that wrapper defaults to vanilla behavior.

I also noticed you are doing some really bad practices. 
https://github.com/Legacy-Visuals-Project/Animatium/blob/1.21.10/development/src/main/java/btw/mixces/animatium/util/EntityUtils.java
This is just asking for issues, especially once minecraft moves all rendering to the render thread.

The correct way to do this kind of logic is by adding your own values within the render states through interfaces injections using mixin.