### PR TITLE
fix server disconnect when throwing an egg

### DIFF
--- a/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/projectiles/MixinThrownEgg_SnowballParticles.java
+++ b/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/projectiles/MixinThrownEgg_SnowballParticles.java
@@ -43,7 +43,7 @@ public abstract class MixinThrownEgg_SnowballParticles {
 		if (Animatium.isEnabled() && AnimatiumConfig.instance().items.eggSnowballParticles) {
 			return new ItemStack(Items.SNOWBALL);
 		} else {
-			return null;
+			return original.call(instance);
 		}
 	}
 }


### PR DESCRIPTION
think this fixes a server disconnect when you throw an egg (you get a disconnect saying $$1 is null and its an item stack). not tested but prolly right