### PR TITLE
refactor(mixins): use getOverlayCoords for damage tint

### DIFF
--- a/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/armor_hurt/MixinCustomHeadLayer_DamageTintArmor.java
+++ b/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/armor_hurt/MixinCustomHeadLayer_DamageTintArmor.java
@@ -35,11 +35,11 @@ import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HeadedModel;
 import net.minecraft.client.model.object.skull.SkullModelBase;
 import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.layers.CustomHeadLayer;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.rendertype.RenderType;
-import net.minecraft.client.renderer.texture.OverlayTexture;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -54,7 +54,7 @@ public abstract class MixinCustomHeadLayer_DamageTintArmor<S extends LivingEntit
         if (Animatium.isEnabled() && AnimatiumConfig.instance().other.damageTintArmor) {
             final SkullModelBase.State modelState = new SkullModelBase.State();
             modelState.animationPos = animationValue;
-            submitNodeCollector.submitModel(model, modelState, poseStack, renderType, lightCoords, OverlayTexture.pack(0, OverlayTexture.v(state.hasRedOverlay)), outlineColor, breakProgress);
+            submitNodeCollector.submitModel(model, modelState, poseStack, renderType, lightCoords, LivingEntityRenderer.getOverlayCoords(state, 0.0F), outlineColor, breakProgress);
         } else {
             original.call(animationValue, poseStack, submitNodeCollector, lightCoords, model, renderType, outlineColor, breakProgress);
         }
@@ -63,7 +63,7 @@ public abstract class MixinCustomHeadLayer_DamageTintArmor<S extends LivingEntit
     @ModifyExpressionValue(method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/LivingEntityRenderState;FF)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/texture/OverlayTexture;NO_OVERLAY:I", opcode = Opcodes.GETSTATIC))
     private int animatium$damageTintArmor(final int original, @Local(argsOnly = true, name = "state") final S state) {
         if (Animatium.isEnabled() && AnimatiumConfig.instance().other.damageTintArmor) {
-            return OverlayTexture.pack(0, OverlayTexture.v(state.hasRedOverlay));
+            return LivingEntityRenderer.getOverlayCoords(state, 0.0F);
         } else {
             return original;
         }

--- a/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/cape/MixinCapeLayer_DamageTintCape.java
+++ b/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/cape/MixinCapeLayer_DamageTintCape.java
@@ -27,9 +27,9 @@ package org.visuals.legacy.animatium.mixins.v1.entity.cape;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.layers.CapeLayer;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
-import net.minecraft.client.renderer.texture.OverlayTexture;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -41,7 +41,7 @@ public abstract class MixinCapeLayer_DamageTintCape {
     @ModifyExpressionValue(method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/AvatarRenderState;FF)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/texture/OverlayTexture;NO_OVERLAY:I", opcode = Opcodes.GETSTATIC))
     private int animatium$damageTintItems(final int original, @Local(argsOnly = true, name = "state") final AvatarRenderState state) {
         if (Animatium.isEnabled() && AnimatiumConfig.instance().extras.damageTintCape) {
-            return OverlayTexture.pack(0, OverlayTexture.v(state.hasRedOverlay));
+            return LivingEntityRenderer.getOverlayCoords(state, 0.0F);
         } else {
             return original;
         }

--- a/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/items/MixinAvatarRenderer_HeldItemArmLogic.java
+++ b/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/items/MixinAvatarRenderer_HeldItemArmLogic.java
@@ -38,7 +38,6 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.player.AvatarRenderer;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 import net.minecraft.client.renderer.rendertype.RenderType;
-import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.ARGB;
@@ -88,7 +87,7 @@ public abstract class MixinAvatarRenderer_HeldItemArmLogic<AvatarLikeEntity exte
         int overlay = packedOverlay;
         if (Animatium.isEnabled() && avatarRenderState != null) {
             if (AnimatiumConfig.instance().extras.damageTintItems) {
-                overlay = OverlayTexture.pack(0, OverlayTexture.v(avatarRenderState.hasRedOverlay));
+                overlay = LivingEntityRenderer.getOverlayCoords(avatarRenderState, 0.0F);
             }
 
             if (AnimatiumConfig.instance().extras.showArmWhileInvisible && avatarRenderState.isInvisible) {

--- a/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/items/MixinItemInHandLayer_DamageTintItems.java
+++ b/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/items/MixinItemInHandLayer_DamageTintItems.java
@@ -29,9 +29,9 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.model.ArmedModel;
 import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.client.renderer.entity.state.ArmedEntityRenderState;
-import net.minecraft.client.renderer.texture.OverlayTexture;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -43,7 +43,7 @@ public abstract class MixinItemInHandLayer_DamageTintItems<S extends ArmedEntity
     @ModifyExpressionValue(method = "submitArmWithItem", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/texture/OverlayTexture;NO_OVERLAY:I", opcode = Opcodes.GETSTATIC))
     private int animatium$damageTintItems(final int original, @Local(argsOnly = true, name = "state") final S state) {
         if (Animatium.isEnabled() && AnimatiumConfig.instance().extras.damageTintItems) {
-            return OverlayTexture.pack(0, OverlayTexture.v(state.hasRedOverlay));
+            return LivingEntityRenderer.getOverlayCoords(state, 0.0F);
         } else {
             return original;
         }

--- a/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/items/MixinPlayerItemInHandLayer_DamageTintArmor.java
+++ b/src/main/java/org/visuals/legacy/animatium/mixins/v1/entity/items/MixinPlayerItemInHandLayer_DamageTintArmor.java
@@ -30,9 +30,9 @@ import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.model.ArmedModel;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HeadedModel;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.layers.PlayerItemInHandLayer;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
-import net.minecraft.client.renderer.texture.OverlayTexture;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -44,7 +44,7 @@ public abstract class MixinPlayerItemInHandLayer_DamageTintArmor<S extends Avata
     @ModifyExpressionValue(method = "renderItemHeldToEye", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/texture/OverlayTexture;NO_OVERLAY:I", opcode = Opcodes.GETSTATIC))
     private int animatium$damageTintItems(final int original, @Local(argsOnly = true, name = "state") final S state) {
         if (Animatium.isEnabled() && AnimatiumConfig.instance().extras.damageTintItems) {
-            return OverlayTexture.pack(0, OverlayTexture.v(state.hasRedOverlay));
+            return LivingEntityRenderer.getOverlayCoords(state, 0.0F);
         } else {
             return original;
         }


### PR DESCRIPTION
Improves mod compatibility, mainly tested with Polyfrost/DamageTint

closes https://github.com/Polyfrost/DamageTint/issues/21